### PR TITLE
Closures p1

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -711,6 +711,15 @@ module Generic =
             }
             genArgs |> GenericArgs.AngleBracketed |> Some
 
+    let mkParenArgs inputs output: GenericArgs =
+        let genArgs: ParenthesizedArgs = {
+            span = DUMMY_SP
+            inputs_span = DUMMY_SP
+            inputs = mkVec inputs
+            output = output
+        }
+        genArgs |> GenericArgs.Parenthesized
+
 [<AutoOpen>]
 module Types =
 
@@ -728,6 +737,34 @@ module Types =
 
     let mkFnTy genParams fnDecl: Ty =
         TyKind.BareFn(mkBareFnTy genParams fnDecl)
+        |> mkTy
+
+    let mkFnTraitGenericBound inputs output =
+        let ptref: Types.PolyTraitRef = {
+            bound_generic_params = mkVec []
+            span = DUMMY_SP
+            trait_ref = {
+                path = {
+                    segments = mkVec [
+                        {
+                            ident = mkIdent "Fn"
+                            id = DUMMY_NODE_ID
+                            args = mkParenArgs inputs output |> Some
+                        }
+                    ]
+                    span = DUMMY_SP
+                    tokens = None
+                }
+                ref_id = DUMMY_NODE_ID
+            }
+        }
+        GenericBound.Trait(ptref, TraitBoundModifier.None)
+
+    let mkTraitsTy traits: Ty =
+        TyKind.TraitObject(mkVec traits, TraitObjectSyntax.None)
+        |> mkTy
+    let mkImplTraitsTy traits =
+        TyKind.ImplTrait(DUMMY_NODE_ID, mkVec traits)
         |> mkTy
 
     let mkRefTy ty: Ty =

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -2439,7 +2439,18 @@ module Util =
         [typeDeclaration; reflectionDeclaration]
 *)
     let typedParam (com: IRustCompiler) ctx (id: Fable.Ident) =
-        let ty = transformType com ctx id.Type
+        let ty =
+            match id.Type with
+            | Fable.Type.LambdaType(arg, t) -> //redirecting a function type to a closure allows greater flexibilty
+                //mkFullNamePathTy "F" None
+                let inputTypes, returnType = uncurryLambdaType ([], id.Type)
+
+                let traitTy =
+                    [mkFnTraitGenericBound (inputTypes |> List.map (transformType com ctx)) (returnType |> transformType com ctx |> Rust.FnRetTy.Ty)]
+                    |> mkImplTraitsTy
+                //transformLambdaType com ctx inputTypes returnType
+                traitTy
+            | _ -> transformType com ctx id.Type
         let isRef = false
         let isMut = false
         mkParamFromType id.Name ty isRef isMut //?loc=id.Range)
@@ -2463,7 +2474,7 @@ module Util =
             |> List.map (typedParam com ctx)
         let fnDecl = mkFnDecl inputs fnRetTy
         let fnBody = com.TransformAsExpr(ctx, body)
-        fnDecl, fnBody
+        fnDecl, fnBody, newTypeParams
 
     let transformLambda (com: IRustCompiler) ctx (args: Fable.Ident list) (body: Fable.Expr) =
         let fnRetTy = VOID_RETURN_TY
@@ -2476,7 +2487,7 @@ module Util =
         mkClosureExpr fnDecl fnBody
 
     let transformModuleFunction (com: IRustCompiler) ctx (info: Fable.MemberInfo) (membName: string) (args: Fable.Ident list) (body: Fable.Expr) =
-        let fnDecl, fnBody = transformFunction com ctx args body
+        let fnDecl, fnBody, fnGenericNames = transformFunction com ctx args body
         let fnBodyBlock =
             if body.Type = Fable.Unit
             then mkSemiBlock fnBody
@@ -2486,14 +2497,9 @@ module Util =
             //it does not seem like the current AST gives access to the actual generic params, so this is inferring them from useage,
             //which is a hack/temporary solution that only works for trivial cases.
             let parameters =
-                args
-                |> List.choose (fun a ->
-                            match a.Type with
-                            | Fable.GenericParam (name, constraints) -> Some (name, constraints)
-                            | _ -> //recurse to find nested params in functions etc?
-                                None)
-                |> List.distinct
-                |> List.map(fun (name, constraints) ->
+                fnGenericNames
+                |> Set.toList
+                |> List.map(fun name ->
                     //todo map constraints
                     mkGenericParam [] (mkIdent (name)) [] false (Rust.AST.Types.GenericParamKind.Type None)
                     )

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="tests/RecordTests.fs" />
     <Compile Include="tests/AnonRecordTests.fs" />
     <Compile Include="tests/StringTests.fs" />
+    <Compile Include="tests/ClosureTests.fs" />
     <!-- <Compile Include="tests/NBodyTests.fs" /> -->
     <Compile Include="src/main.fs" />
   </ItemGroup>

--- a/tests/Rust/tests/ClosureTests.fs
+++ b/tests/Rust/tests/ClosureTests.fs
@@ -1,0 +1,43 @@
+module Fable.Tests.Closure
+
+open Util.Testing
+
+let map f x =
+    f x
+
+let staticFnAdd1 x = x + 1
+
+[<Fact>]
+let ``fn as param should also accept static functions`` () =
+    let a = 3
+    let b = 2
+
+    a |> equal 3
+    b |> equal 2
+    a |> map staticFnAdd1 |> equal 4
+    b |> map staticFnAdd1 |> equal 3
+
+
+[<Fact>]
+let ``Closure captures trivial case variable and does not break borrow checker`` () =
+    let a = 3
+    let b = 2
+
+    let res = a |> map (fun x -> b + x)//b is captured, so it is borrowed
+    a |> equal 3
+    b |> equal 2
+    res |> equal 5
+
+type Wrapped = {
+    Value: string
+}
+
+[<Fact>]
+let ``Closure captures and clones`` () =
+    let a = { Value = "a" }
+    let b = { Value = "b" }
+
+    let res1 = a |> map (fun x -> x.Value + b.Value)//capture b, clone
+    let res2 = a |> map (fun x -> x.Value + b.Value + "x")//capture b, clone
+    res1 |> equal "ab"
+    res2 |> equal "abx"


### PR DESCRIPTION
Early stab at closures. Got some trivial cases running, including interchange between static functions and closures. There are still some problems - namely inline type definitions for closures are not working at the moment.

As for the more complex scenarios, I am pretty confident I have the solution (after much experimentation), but it is going to be a little fiddly. The bottom line is that every closure needs to follow this pattern:

```
 let h2 = std::thread::spawn({
                        let rc = rc.clone(); //this is an Arc
                        let c = c.clone(); //this is another Fn closure, it can be cloned, and within it will clone captured Arc's.
                        move || {
                            let r = map5(c, Arc::from("def"));    
                        }
                    });
```

All Arc's need to be cloned and then moved into the closure. Any captured closures also need to be cloned. This seems to work in all single and multi threaded experiments I could think of. I will attach below.

The big puzzle here is going to be working out how to get a list of the variables that are about to be captured in a closure.

Oh, the plus note is we do not need reference tracking for this solution to work. Win.