### PR TITLE
Closures part 2

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -593,7 +593,7 @@ module Exprs =
         |> mkExpr
 
     let mkClosureExpr (decl: FnDecl) (body: Expr): Expr =
-        ExprKind.Closure(CaptureBy.Ref, Asyncness.No, Movability.Movable, decl, body, DUMMY_SP)
+        ExprKind.Closure(CaptureBy.Value, Asyncness.No, Movability.Movable, decl, body, DUMMY_SP)
         |> mkExpr
 
     let mkCallExpr (callee: Expr) args: Expr =

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="tests/RecordTests.fs" />
     <Compile Include="tests/AnonRecordTests.fs" />
     <Compile Include="tests/StringTests.fs" />
+    <Compile Include="tests/ClosureTests.fs" />
     <Compile Include="tests/NBodyTests.fs" />
     <Compile Include="src/main.fs" />
   </ItemGroup>

--- a/tests/Rust/tests/ClosureTests.fs
+++ b/tests/Rust/tests/ClosureTests.fs
@@ -41,3 +41,89 @@ let ``Closure captures and clones`` () =
     let res2 = a |> map (fun x -> x.Value + b.Value + "x")//capture b, clone
     res1 |> equal "ab"
     res2 |> equal "abx"
+
+[<Fact>]
+let ``Closure can be declared locally and passed to a fn`` () =
+
+    let x = "x"
+    let cl s = s + x
+
+    let res1 = "a." |> map (cl)//capture b, clone
+    let res2 = "b." |> map (cl)//capture b, clone
+    x |> equal "x"// prevent inlining
+    res1 |> equal "a.x"
+    res2 |> equal "b.x"
+
+[<Fact>]
+let ``Closure can close over another closure and call`` () =
+    let x = "x"
+    let cl1 s = s + x
+    let cl2 s = cl1 s + x
+
+    let res1 = "a." |> map (cl2)//capture b, clone
+    let res2 = "b." |> map (cl2)//capture b, clone
+    let res3 = "c." |> map (cl1)//capture b, clone
+    x |> equal "x"// prevent inlining
+    res1 |> equal "a.xx"
+    res2 |> equal "b.xx"
+    res3 |> equal "c.x"
+
+[<Fact>]
+let ``Closures can accept multiple params`` () =
+    let x = { Value = "x"}
+    let cl a b c =
+        (a + b + c + x.Value)
+
+    let res1 = cl "a" "b" "c"
+    let res2 = cl "d" "e" "f"
+
+    x.Value |> equal "x" // prevent inlining
+    res1 |> equal "abcx"
+    res2 |> equal "defx"
+
+
+[<Fact>]
+let ``parameterless closure works - unit type in`` () =
+    let x = { Value = "x"}
+    let cl () =
+        ("closed." + x.Value)
+
+    let res1 = cl()
+    let res2 = cl()
+    x.Value |> equal "x" // prevent inlining
+    res1 |> equal "closed.x"
+    res2 |> equal "closed.x"
+
+// TODO : mutable x probably needs to be a Arc<RefCell<T>>?
+// TODO : Support unit return type
+// [<Fact>]
+// let ``Mutable capture works`` () =
+//     let mutable x = 0
+//     let incrementX () =
+//         x <- x + 1
+//         ()
+
+//     incrementX()
+//     x |> equal 1
+//     incrementX()
+//     x |> equal 2
+//     incrementX()
+//     x |> equal 3
+
+type MutWrapped = {
+    mutable MutValue: int
+}
+
+[<Fact>]
+let ``Capture works with type with interior mutability`` () =
+    let x = { MutValue = 0 }
+    let incrementX () =
+        x.MutValue <- x.MutValue + 1
+        0// TODO : support unit
+
+    incrementX()
+    x.MutValue |> equal 1
+    incrementX()
+    x.MutValue |> equal 2
+    incrementX()
+    x.MutValue |> equal 3


### PR DESCRIPTION
* Closures now capture rc's using the clone and move syntax discussed previously.
* Closures can capture other closures (and will clone them)
* Closures now are defined with compatible types (function parameters defined as impl trait, inline as trait), and fn pointers can be passed to a function expecting a impl Fn trait.
* Fixed a couple of other minor nagging issues around curried applies not correctly throwing out unit's etc.

I found a rather fun problem around capturing mutable variables, which just, doesn't work heh. Test is there but commented out as it blows up. I think we might need to wrap any mutable locally defined let variables into a `Rc<RefCell<T>>` so as to capture them immutably with interior mutability, same as for structs. If we do not do this we need to use FnMut, which has a bunch of really tight constraints that may well be hard to work around. Curious what your thoughts are on this anyway @ncave.