### PR TITLE
References in owner out

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -561,6 +561,9 @@ module Exprs =
         ExprKind.Unary(op, arg)
         |> mkExpr
 
+    let mkDerefExpr expr =
+        mkUnaryExpr UnOp.Deref expr
+
     let mkBinaryExpr op left right: Expr =
         ExprKind.Binary(op, left, right)
         |> mkExpr

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -284,6 +284,9 @@ module Patterns =
         PatKind.TupleStruct(path, mkVec fields)
         |> mkPat
 
+    let mkRefPat pat =
+        PatKind.Ref(pat, Mutability.Not) |> mkPat
+
 [<AutoOpen>]
 module Visibilities =
 

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1258,11 +1258,11 @@ module Util =
                     let attrs = []
                     let ident = mkIdent fi.Name
                     let expr =
+                        let ctx = { ctx with Typegen = { ctx.Typegen with TakingOwnership = true}}
                         if fi.IsMutable then
                             com.TransformAsExpr(ctx, value)
                             |> makeMutValue com ctx fi.FieldType
                         else
-                            let ctx = { ctx with Typegen = { ctx.Typegen with TakingOwnership = true}}
                             transformLeaveContextByValue com ctx fi.FieldType None value
                     mkExprField attrs ident expr false false)
             let genArgs = genArgs |> List.map (transformType com ctx) |> mkGenericArgs

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1120,7 +1120,6 @@ module Util =
         let mkClone expr = mkMethodCallExpr "clone" None expr []
         /// Calling this on an rc guarantees a &T, regardless of if the Rc is a ref or not
         let mkAsRef expr = mkMethodCallExpr "as_ref" None expr []
-    // For any ref counted types, these sometimes need to be unwrapped for pattern matching purposes etc
 
     let makeRefValue (com: IRustCompiler) ctx (value: Rust.Expr) =
         let callee = mkGenericPathExpr ["Rc";"from"] None
@@ -2872,8 +2871,6 @@ module Util =
             )
         let attrs = [mkAttr "derive" ["Clone";"PartialEq";"Debug"]];
         let structItem = mkStructItem attrs entName fields generics
-        //ent.MembersFunctionsAndValues |> Seq.map(fun e -> e.)
-
         [structItem]// TODO: add traits for attached members
 
     let transformClassDecl (com: IRustCompiler) ctx (decl: Fable.ClassDecl) =

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1755,7 +1755,7 @@ module Util =
                 if ident.IsMutable
                 then init |> makeMutValue com ctx ident.Type
                 else init
-            let local = mkLocal [] pat tyOpt (Some init)
+            let local = mkLocal [] pat tyOpt (Some expr)
             // TODO : traverse body and follow references to decide on if this should be wrapped or not]
             let useages = UseageTracking.calcIdentUseages body
             let scopedVarAttrs = {  IsRef = isRef

--- a/src/fable-library-rust/Option.rs
+++ b/src/fable-library-rust/Option.rs
@@ -1,15 +1,15 @@
 pub mod Option {
     use std::rc::Rc;
 
-    pub fn get<T: Clone>(opt: Rc<Option<T>>) -> T {
-        match opt.as_ref() {
+    pub fn get<T: Clone>(opt: &Rc<Option<T>>) -> T {
+        match (*opt).as_ref() {
             Some(x) => x.clone(),
             None => panic!("Option has no value")
         }
     }
 
-    pub fn map<T: Clone, U: Clone>(opt: Rc<Option<T>>, mapping: impl Fn(T) -> U) -> Rc<Option<U>> {
-        match opt.as_ref() {
+    pub fn map<T: Clone, U: Clone>(opt: &Rc<Option<T>>, mapping: &impl Fn(T) -> U) -> Rc<Option<U>> {
+        match (*opt).as_ref() {
             Some(x) => Rc::from(Some(mapping(x.clone()))),
             None => Rc::from(None)
         }

--- a/tests/Rust/tests/ClosureTests.fs
+++ b/tests/Rust/tests/ClosureTests.fs
@@ -127,3 +127,14 @@ let ``Capture works with type with interior mutability`` () =
     x.MutValue |> equal 2
     incrementX()
     x.MutValue |> equal 3
+
+// type CTest(x: int, y: string) =
+//     let a = x + x
+//     let y = y
+//     member this.Add m = a + m
+
+// [<Fact>]
+// let ``Class hellp`` () =
+//     let a = CTest(1, "hello")
+//     let r = a.Add(1)
+//     r |> equal 3

--- a/tests/Rust/tests/UnionTests.fs
+++ b/tests/Rust/tests/UnionTests.fs
@@ -48,7 +48,30 @@ let ``Union fn call works`` () =
 type WrappedUnion =
     | AString of string
 
-// let ``Union with wrapped type works`` () =
-//     let a = AString "hello"
-//     let b = match a with AString s -> s + " world"
-//     b |> equal "hello world"
+let ``Union with wrapped type works`` () =
+    let a = AString "hello"
+    let b = match a with AString s -> s + " world"
+    b |> equal "hello world"
+
+type DeepRecord = {Value: string}
+type DeepWrappedUnion =
+    //| DeepWrappedA of string * DeepRecord
+    | DeepWrappedB of string
+    | DeepWrappedC of int
+    //| DeepWrappedD of DeepRecord    //does not yet work
+
+let matchStrings = function
+    //| DeepWrappedA (s, d) -> d.Value + s //todo - not working
+    | DeepWrappedB s -> s
+    | DeepWrappedC c -> "nothing"
+    //| DeepWrappedD d -> d.Value //todo - not working
+
+let ``Deep union with wrapped type works`` () =
+    //let a = DeepWrappedA (" world", {Value = "hello"})
+    let b = DeepWrappedB "world"
+    let c = DeepWrappedC 42//todo to string!
+    //let d = DeepWrappedD { Value = "hello" }//todo to string!
+    //a |> matchStrings |> equal "hello world"
+    b |> matchStrings |> equal "world"
+    c |> matchStrings |> equal "nothing"
+   // d |> matchStrings |> equal "hello"


### PR DESCRIPTION
Initial implementation of references in to all functions, owner out.

* Implementeed ref tracking early early prototype
* Added context so that idents can be looked up - again super early prototype
* Added better unwrapping ref/value dependent on context
* Got a couple more edge cases fixed
* Match statements now run using refs

I fully expect you will either want to tear half of this apart or start again, but I think the ideas within this at least seem like progress. The more I think about this we definitely do not want to be passing things into functions by value where we can avoid it, because it creates a huge amount of necessary cloning any time you pass over a boundary. Also, the ability to track if a type is wrapped or a ref, depending on how it is defined, is important. At the moment, it is pretty dumb - if its a function parameter and can be a ref, it is a ref, otherwise it is a value. Based off that we can then decide how to unwrap it.