### PR TITLE
Fix some edge cases around unions

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -474,7 +474,10 @@ let testRust() =
     runInDir testAstDir "dotnet test"
     runInDir projectDir "dotnet test"
 
-    cleanDirs [buildDir]
+    //reduce io churn, speed up rebuilds, and save the ssd (target folder can get huge)
+    cleanDirs [buildDir + "/src"]
+    cleanDirs [buildDir + "/tests"]
+    cleanDirs [buildDir + "/.fable"]
     runFableWithArgs projectDir [
         "--outDir " + buildDir
         "--exclude Fable.Core"

--- a/tests/Rust/tests/RecordTests.fs
+++ b/tests/Rust/tests/RecordTests.fs
@@ -110,6 +110,7 @@ type StructRecord = {
 let processStructByValue (s: StructRecord) =
     s, s.i + 1
 
+[<Fact>]
 let ``Struct record works`` () =
     let r1 = { i=1; s="hello" }
     let r2 = { i=1; s="world" }

--- a/tests/Rust/tests/StringTests.fs
+++ b/tests/Rust/tests/StringTests.fs
@@ -24,3 +24,4 @@ let ``String equality works`` () =
     s1 |> equal s2
     (s1 = s2) |> equal true
     (s1 = s3) |> equal false
+    //(s1 <> s3) |> equal true

--- a/tests/Rust/tests/UnionTests.fs
+++ b/tests/Rust/tests/UnionTests.fs
@@ -56,15 +56,15 @@ let ``Union with wrapped type works`` () =
 
 type DeepRecord = {Value: string}
 type DeepWrappedUnion =
-    | DeepWrappedA of string * DeepRecord //not working yet - does not render pattern correctly (no variables bound)
+    | DeepWrappedA of string * DeepRecord
     | DeepWrappedB of string
     | DeepWrappedC of int
     | DeepWrappedD of DeepRecord
     | DeepWrappedE of int * int
-    | DeepWrappedF of WrappedUnion //not working yet - creates a panic!(Error(&(Rc::from("Match failure: Fable.Tests.Union.DeepWrappedUnion") where Error is not defined yet
+    | DeepWrappedF of WrappedUnion
     | DeepWrappedG of {| X: DeepRecord; Y: int|}
 let matchStrings = function
-    | DeepWrappedA (s, d) -> d.Value + s //todo - not working
+    | DeepWrappedA (s, d) -> d.Value + s
     | DeepWrappedB s -> s
     | DeepWrappedC c -> "nothing"
     | DeepWrappedD d -> d.Value
@@ -105,7 +105,6 @@ let ``Deep union with tuped prim type works`` () =
     c |> matchNumbers |> equal 42
     g |> matchNumbers |> equal 365
 
-// // this tests is breaking if uncommented
 [<Fact>]
 let ``Multi-case Union with wrapped type works`` () =
     let b = DeepWrappedB "hello"

--- a/tests/Rust/tests/UnionTests.fs
+++ b/tests/Rust/tests/UnionTests.fs
@@ -48,6 +48,7 @@ let ``Union fn call works`` () =
 type WrappedUnion =
     | AString of string
 
+[<Fact>]
 let ``Union with wrapped type works`` () =
     let a = AString "hello"
     let b = match a with AString s -> s + " world"
@@ -55,29 +56,69 @@ let ``Union with wrapped type works`` () =
 
 type DeepRecord = {Value: string}
 type DeepWrappedUnion =
-    //| DeepWrappedA of string * DeepRecord
+    | DeepWrappedA of string * DeepRecord //not working yet - does not render pattern correctly (no variables bound)
     | DeepWrappedB of string
     | DeepWrappedC of int
-    //| DeepWrappedD of DeepRecord    //does not yet work
-
+    | DeepWrappedD of DeepRecord
+    | DeepWrappedE of int * int
+    | DeepWrappedF of WrappedUnion //not working yet - creates a panic!(Error(&(Rc::from("Match failure: Fable.Tests.Union.DeepWrappedUnion") where Error is not defined yet
+    | DeepWrappedG of {| X: DeepRecord; Y: int|}
 let matchStrings = function
-    //| DeepWrappedA (s, d) -> d.Value + s //todo - not working
+    | DeepWrappedA (s, d) -> d.Value + s //todo - not working
     | DeepWrappedB s -> s
     | DeepWrappedC c -> "nothing"
-    //| DeepWrappedD d -> d.Value //todo - not working
+    | DeepWrappedD d -> d.Value
+    | DeepWrappedE(a, b) -> "nothing2"
+    | DeepWrappedF (AString s) -> s
+    | DeepWrappedG x -> x.X.Value
 
+let matchNumbers = function
+    | DeepWrappedA (s, d) -> 0
+    | DeepWrappedB s -> 0
+    | DeepWrappedC c -> c
+    | DeepWrappedD d -> 0
+    | DeepWrappedE(a, b) -> a + b
+    | DeepWrappedF _ -> 0
+    | DeepWrappedG x -> x.Y
+
+[<Fact>]
 let ``Deep union with wrapped type works`` () =
-    //let a = DeepWrappedA (" world", {Value = "hello"})
+    let a = DeepWrappedA (" world", {Value = "hello"})
     let b = DeepWrappedB "world"
-    let c = DeepWrappedC 42//todo to string!
-    //let d = DeepWrappedD { Value = "hello" }//todo to string!
-    //a |> matchStrings |> equal "hello world"
+    let c = DeepWrappedC 42
+    let d = DeepWrappedD { Value = "hello" }
+    let f = DeepWrappedF (AString "doublewrapped")
+    let g = DeepWrappedG {|X={Value="G"}; Y=365|}
+    a |> matchStrings |> equal "hello world"
     b |> matchStrings |> equal "world"
     c |> matchStrings |> equal "nothing"
-   // d |> matchStrings |> equal "hello"
+    d |> matchStrings |> equal "hello"
+    f |> matchStrings |> equal "doublewrapped"
+    g |> matchStrings |> equal "G"
+
+[<Fact>]
+let ``Deep union with tuped prim type works`` () =
+    let e = DeepWrappedE (3, 2)
+    let c = DeepWrappedC 42//todo to string!
+    let g = DeepWrappedG {|X={Value="G"}; Y=365|}
+    e |> matchNumbers |> equal 5
+    c |> matchNumbers |> equal 42
+    g |> matchNumbers |> equal 365
 
 // // this tests is breaking if uncommented
-// let ``Multi-case Union with wrapped type works`` () =
-//     let b = DeepWrappedB "hello"
-//     let res = match b with DeepWrappedB s -> s + " world" | _ -> ""
-//     res |> equal "hello world"
+[<Fact>]
+let ``Multi-case Union with wrapped type works`` () =
+    let b = DeepWrappedB "hello"
+    let res = match b with DeepWrappedB s -> s + " world" | _ -> ""
+    res |> equal "hello world"
+
+let matchStringWhenStringNotHello = function
+    | DeepWrappedB s when s = "hello" -> s //todo - not operator <> seems to not work
+    | _ -> "not hello"
+
+[<Fact>]
+let ``Match with condition works`` () =
+    let b1 = DeepWrappedB "hello"
+    let b2 = DeepWrappedB "not"
+    b1 |> matchStringWhenStringNotHello |> equal "hello"
+    b2 |> matchStringWhenStringNotHello |> equal "not hello"


### PR DESCRIPTION
Incremental progress:

* Unions now work correctly with deep expressions referencing them. Previously only a raw ident in the subtree would work.
* Fixed a few subtle issues around unwrapping and managing Rc's
* Added slightly better ident finding in context when trying to work out if to unwrap something or similar
* Adjusted the build script to hammer SSD less! Can kick this out if you don't like it, but there are benefits - namely being able to leave vscode open in the root folder, and not having it be closed on every rebuild, including faster builds. Let me know
* Add Fact attr to some intended tests that weren't actually running. Turns out you need that to make tests run :p

New findings:
* Not operator doesn't seem to work. You end up with equals. Cannot work out why.