### PR TITLE
Ref uniform edge case

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1334,7 +1334,7 @@ module Util =
                 expr |> mkAddrOfExpr
             else expr
         else
-            makeClone expr
+            expr |> mkDerefExpr
 
     let transformLeaveContextByValue (com: IRustCompiler) ctx (t: Fable.Type option) (name: string option) (e: Fable.Expr): Rust.Expr =
         let expr = com.TransformAsExpr (ctx, e)

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1330,11 +1330,11 @@ module Util =
         let expr = com.TransformAsExpr (ctx, e)
         let varAttrs, isOnlyReference = calcVarAttrsAndOnlyRef com ctx e.Type None e
         if shouldBePassByRefForParam com e.Type then
-            expr |> mkAddrOfExpr
-        elif isCloneable com e.Type && not isOnlyReference then
-            makeClone expr
+            if not varAttrs.IsRef then
+                expr |> mkAddrOfExpr
+            else expr
         else
-            expr
+            makeClone expr
 
     let transformLeaveContextByValue (com: IRustCompiler) ctx (t: Fable.Type option) (name: string option) (e: Fable.Expr): Rust.Expr =
         let expr = com.TransformAsExpr (ctx, e)

--- a/tests/Rust/tests/ClosureTests.fs
+++ b/tests/Rust/tests/ClosureTests.fs
@@ -5,17 +5,23 @@ open Util.Testing
 let map f x =
     f x
 
+let staticFnPassthrough x = x   //uniform parameters
+
 let staticFnAdd1 x = x + 1
 
 [<Fact>]
 let ``fn as param should also accept static functions`` () =
     let a = 3
     let b = 2
+    let w = {|X = 1|}
 
     a |> equal 3
     b |> equal 2
     a |> map staticFnAdd1 |> equal 4
     b |> map staticFnAdd1 |> equal 3
+    a |> map staticFnPassthrough |> equal 3
+    let wRes = w |> map staticFnPassthrough
+    wRes.X |> equal 1
 
 
 [<Fact>]


### PR DESCRIPTION
Just a small one, couldn't help myself. The uniform parameters thing, I didn't believe you, so suffer and learn the hard way what you were talking about haha. As for the problem, it is quite clear to me now - when you share generic parameters for the params AND the return type, it gets super confused because it infers if it is a ref or not from the generic.

I have added a trivial example of a ( T -> T) passthrough function, which broke everything before. I have tweaked the shouldBePassByRefForParam so this now correctly dereferences etc. Also to clarify, we also do not want to be cloning when borrowing because it returns a value type, so I have tweaked this also.

It sucks that everything has to be uniform, but I cannot see any way around it either. Will have a good think.