### PR TITLE
Constructors first pass

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -982,6 +982,22 @@ module Items =
           ident = ident
           kind = kind
           tokens = None }
+    let mkItemInh attrs ident kind: Item =
+        { attrs = mkVec attrs
+          id = DUMMY_NODE_ID
+          span = DUMMY_SP
+          vis = INHERITED_VIS
+          ident = ident
+          kind = kind
+          tokens = None }
+    let mkAssocItem attrs ident kind: Item<AssocItemKind> =
+        { attrs = mkVec attrs
+          id = DUMMY_NODE_ID
+          span = DUMMY_SP
+          vis = PUBLIC_VIS
+          ident = ident
+          kind = kind
+          tokens = None }
 
     let mkNonPublicItem item: Item =
         { item with vis = INHERITED_VIS }
@@ -990,6 +1006,10 @@ module Items =
         let ident = mkIdent name
         ItemKind.Fn kind
         |> mkItem attrs ident
+    let mkAssocFnItem attrs name kind: AssocItem =
+        let ident = mkIdent name
+        AssocItemKind.Fn kind
+        |> mkAssocItem attrs ident
 
     let mkUseItem attrs names kind: Item =
         let mkUseTree prefix kind: UseTree =
@@ -1059,6 +1079,20 @@ module Items =
         let def = Defaultness.Final
         ItemKind.Const(def, ty, exprOpt)
         |> mkItem attrs ident
+
+    let mkImplItem attrs name ty genericParams items: Item =
+        let ident = mkIdent name
+        ItemKind.Impl({
+            unsafety = Unsafety.No
+            polarity = ImplPolarity.Positive
+            defaultness = Defaultness.Final
+            constness = Constness.No
+            generics = mkGenerics genericParams
+            of_trait = None
+            self_ty = ty
+            items = mkVec items
+        })
+        |> mkItemInh attrs ident
 
     let TODO_ITEM (name: string): Item =
         let attrs = []

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="tests/AnonRecordTests.fs" />
     <Compile Include="tests/StringTests.fs" />
     <Compile Include="tests/ClosureTests.fs" />
+    <Compile Include="tests/ClassTests.fs" />
     <Compile Include="tests/NBodyTests.fs" />
     <Compile Include="src/main.fs" />
   </ItemGroup>

--- a/tests/Rust/tests/ClassTests.fs
+++ b/tests/Rust/tests/ClassTests.fs
@@ -1,0 +1,19 @@
+module Fable.Tests.ClassTests
+
+open Util.Testing
+
+type CTest(x: int, y: int) =
+    let a = x + y
+    // print "%i %i" x y
+    //member this.A = a
+    // member this.B = 1
+    member this.Add m = a + m
+
+[<Fact>]
+let ``Class instance comparisons work`` () = //this is inconsistent with .net since structural equality is not the default with classes
+    let a = CTest(1, 2)
+    let b = CTest(3, 4)
+    // let r = a.Add(1)
+    // r |> equal 4
+    a |> equal a
+    a |> notEqual b

--- a/tests/Rust/tests/ClosureTests.fs
+++ b/tests/Rust/tests/ClosureTests.fs
@@ -133,14 +133,3 @@ let ``Capture works with type with interior mutability`` () =
     x.MutValue |> equal 2
     incrementX()
     x.MutValue |> equal 3
-
-// type CTest(x: int, y: string) =
-//     let a = x + x
-//     let y = y
-//     member this.Add m = a + m
-
-// [<Fact>]
-// let ``Class hellp`` () =
-//     let a = CTest(1, "hello")
-//     let r = a.Add(1)
-//     r |> equal 3


### PR DESCRIPTION
This is far from working in any consequential way but it seemed like the minimum unit of work that was self testable, and it raises a bunch of points and questions you probably are interested in @ncave .

**This introduces class constructors.**

I basically had to rewrite the body expression of the constructor, because javascript creates a mutable object and starts mutating its properties. We obviously cannot do this, and must create a new struct instance in a single expression. I presume this method has all sorts of holes in it, but curious what your thoughts are. I had to add exemptions to create impl blocks for Records, otherwise the world breaks at the moment.

I couldn't get methods working yet either. This is actually a bit of a can of worms because the methods exist at the module level, and need to be moved into the class impl declaration, and there is nowhere in the fable ast to inject them.

I also have done some ropey string replace to get constructor calls wrong. I am sure this is wrong, so again, happy to change.
More to come.