### PR TITLE
Working classes

### DIFF
--- a/tests/Rust/tests/ClassTests.fs
+++ b/tests/Rust/tests/ClassTests.fs
@@ -2,18 +2,54 @@ module Fable.Tests.ClassTests
 
 open Util.Testing
 
-type CTest(x: int, y: int) =
+type NTest(x: int, y: int) =
     let a = x + y
     // print "%i %i" x y
-    //member this.A = a
-    // member this.B = 1
+    member this.A = a
+    member this.B = 1
     member this.Add m = a + m
+    member this.Minus m = a - m
+    member this.Mul (c, d) = a * c * d
+
+type STest(s: string) =
+    member this.Append x = s + x
 
 [<Fact>]
-let ``Class instance comparisons work`` () = //this is inconsistent with .net since structural equality is not the default with classes
-    let a = CTest(1, 2)
-    let b = CTest(3, 4)
-    // let r = a.Add(1)
-    // r |> equal 4
+let ``Class imm methods and props work for prim ints`` () =
+    let a = NTest(1, 2)
+    let b = NTest(3, 4)
+    let r = a.Add(1)
+    r |> equal 4
+    a.Add(2) |> equal 5
+    b.Add(2) |> equal 9
+    a.Minus(3) |> equal 0
+    b.Mul(3, 2) |> equal 42
+    a.A |> equal 3
+    b.A |> equal 7
+    a.B |> equal 1
+
+[<Fact>]
+let ``Class comparisons work`` () = //this is inconsistent with .net since structural equality is not the default with classes
+    let a = NTest(1, 2)
+    let b = NTest(3, 4)
     a |> equal a
     a |> notEqual b
+
+[<Fact>]
+let ``Class imm methods and props work for strings`` () =
+    let a = STest("hello")
+    let res = a.Append " world"
+    res |> equal "hello world"
+
+// TODO - not yet working - weird NULL and type: Any expressions coming out
+type SWrapper(a: STest, b: STest, c: NTest) =
+    member this.AddStrings x =
+        a.Append (b.Append x)
+    member this.AddNum x =
+        c.Add x
+
+[<Fact>]
+let ``Class taking other classes as params should work`` () =
+    let a = SWrapper(STest("a"), STest("b"), NTest(1, 2))
+    a.AddStrings "c" |> equal "abc"
+    a.AddNum 2 |> equal 5


### PR DESCRIPTION
### Classes that actually work (well, sort of)

* Transform ctor to work with Rust immutable declaration syntax
* Class methods now transform
* Class methods end up in an impl block
* Ignored the self problem, _this comes out the compiler, and works great with Rc's, so this is a pretty reasonable compromise, just not particularly Rust'y. The Rc wrapper will be necessary for some methods anyway if they consume the self reference and embed it into something else, thus transferring ownership. (IEnumerator presumably will hit this).
* Ident useages now do not count shadowed stuff

Can we unwrap a Sequential into a function body? I got an unnecessary ctor seuqnetial I cannot get rid of and it is making an unnecessary clone.