### PR TITLE
ByRef closures

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -654,7 +654,7 @@ module Exprs =
         |> mkExpr
 
     let mkClosureExpr (decl: FnDecl) (body: Expr): Expr =
-        ExprKind.Closure(CaptureBy.Value, Asyncness.No, Movability.Movable, decl, body, DUMMY_SP)
+        ExprKind.Closure(CaptureBy.Ref, Asyncness.No, Movability.Movable, decl, body, DUMMY_SP)
         |> mkExpr
 
     let mkCallExpr (callee: Expr) args: Expr =

--- a/tests/Rust/tests/ClosureTests.fs
+++ b/tests/Rust/tests/ClosureTests.fs
@@ -100,21 +100,20 @@ let ``parameterless closure works - unit type in`` () =
     res1 |> equal "closed.x"
     res2 |> equal "closed.x"
 
-// TODO : mutable x probably needs to be a Arc<RefCell<T>>?
 // TODO : Support unit return type
-// [<Fact>]
-// let ``Mutable capture works`` () =
-//     let mutable x = 0
-//     let incrementX () =
-//         x <- x + 1
-//         ()
+[<Fact>]
+let ``Mutable capture works`` () =
+    let mutable x = 0
+    let incrementX () =
+        x <- x + 1
+        ()
 
-//     incrementX()
-//     x |> equal 1
-//     incrementX()
-//     x |> equal 2
-//     incrementX()
-//     x |> equal 3
+    incrementX()
+    x |> equal 1
+    incrementX()
+    x |> equal 2
+    incrementX()
+    x |> equal 3
 
 type MutWrapped = {
     mutable MutValue: int


### PR DESCRIPTION
@alexswan10k
> closures in our implementation are capture by move, not by reference

But do they have to be, though? This is passing all tests, including the mutable one.