### PR TITLE
Implement interfaces first pass

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -1031,6 +1031,8 @@ module Items =
 
     let mkNonPublicItem item: Item =
         { item with vis = INHERITED_VIS }
+    let mkPublicItem item: Item =
+        { item with vis = PUBLIC_VIS }
 
     let mkFnItem attrs name kind: Item =
         let ident = mkIdent name
@@ -1085,7 +1087,7 @@ module Items =
         let ident = mkIdent name
         ItemKind.Trait(IsAuto.No, Unsafety.No, mkGenerics generics, mkVec bounds, mkVec fields)
         |> mkItem attrs ident
-        |> mkNonPublicItem
+        |> mkPublicItem
 
     let mkEnumItem attrs name variants generics: Item =
         let ident = mkIdent name

--- a/tests/Rust/tests/ClassTests.fs
+++ b/tests/Rust/tests/ClassTests.fs
@@ -85,15 +85,14 @@ let ``Class interface impl works trivial`` () =
     let res = aCasted.Add 2 1
     res |> equal 4
 
-// This will therefore not compile - Interface does not exist as is erased
-// let doAddWithInterface (i: IHasAdd) =
-//     i.Add 3 4
+let doAddWithInterface (i: IHasAdd) =
+    i.Add 3 4
 
-// [<Fact>]
-// let ``Class interface with callout works`` () =
-//     let a = WithInterface(1)
-//     let aCasted = (a :> IHasAdd)
-//     let res = doAddWithInterface aCasted
-//     let res2 = doAddWithInterface a
-//     res |> equal 8
-//     res2 |> equal 8
+[<Fact>]
+let ``Class interface with callout works`` () =
+    let a = WithInterface(1)
+    let aCasted = (a :> IHasAdd)
+    let res = doAddWithInterface aCasted
+    let res2 = doAddWithInterface a
+    res |> equal 8
+    res2 |> equal 8


### PR DESCRIPTION
A first pass at interfaces.

Lots to do yet such as generics, and deduplication, and the interface in different than declared namespace problem.

The way this hacks up methods into interface implementation methods and non is a bit primitive, and will probably break on complex scenarios like overloads etc. Needs some tuning. I also imagine we will have the same problems of passing around dn's as we did with closures, so that's another one for another day.

I still don't know a good way round double wrapping here, but perhaps there is a way. The problem again is that you do not want to implement against the raw struct incase someone wants to clone the rc reference in a method.