### PR TITLE
Multi impl interface support p1

### DIFF
--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="tests/AnonRecordTests.fs" />
     <Compile Include="tests/StringTests.fs" />
     <Compile Include="tests/ClosureTests.fs" />
+    <Compile Include="tests/ClassInterfaceTests.fs" />
     <Compile Include="tests/ClassTests.fs" />
     <Compile Include="tests/NBodyTests.fs" />
     <Compile Include="src/main.fs" />

--- a/tests/Rust/tests/ClassInterfaceTests.fs
+++ b/tests/Rust/tests/ClassInterfaceTests.fs
@@ -1,0 +1,40 @@
+module Fable.Tests.ClassInterfaceTests
+
+open Util.Testing
+
+//PROBLEM - Interfaces are not on the AST - this is erased
+type IHasAdd =
+    abstract Add: x: int -> y: int -> int
+
+type WithInterface(m: int) =
+    interface IHasAdd with
+      member this.Add x y = x + y + m
+
+[<Fact>]
+let ``Class interface impl works trivial`` () =
+    let a = WithInterface(1)
+    let aCasted = (a :> IHasAdd)
+    let res = aCasted.Add 2 1
+    res |> equal 4
+
+let doAddWithInterface (i: IHasAdd) =
+    i.Add 3 4
+
+[<Fact>]
+let ``Class interface with callout works`` () =
+    let a = WithInterface(1)
+    let aCasted = (a :> IHasAdd)
+    let res = doAddWithInterface aCasted
+    let res2 = doAddWithInterface a
+    res |> equal 8
+    res2 |> equal 8
+
+type WithInterface2 (m: int) = //todo parameterless constructors fail catastrophically - TODO_EXPR_ObjectExpr ([], Any, None)
+    interface IHasAdd with
+      member this.Add x y = x + y - m
+
+[<Fact>]
+let ``Second class implementing same interface also works`` () =
+    let a = WithInterface2(1)
+    let res = doAddWithInterface a
+    res |> equal 6

--- a/tests/Rust/tests/ClassTests.fs
+++ b/tests/Rust/tests/ClassTests.fs
@@ -70,29 +70,14 @@ let ``Class fluent/builder internal clone pattern should work`` () =
     let res = b.DoFluentAndReturnSelf(1).DoFluentAndReturnSelf(2).DoFluentAndReturnInner(3).X
     res |> equal 42
 
-//PROBLEM - Interfaces are not on the AST - this is erased
-type IHasAdd =
-    abstract Add: x: int -> y: int -> int
-
-type WithInterface(m: int) =
-    interface IHasAdd with
+type WithCrossModuleInterface(m: int) =
+    interface Fable.Tests.ClassInterfaceTests.IHasAdd with
       member this.Add x y = x + y + m
 
 [<Fact>]
-let ``Class interface impl works trivial`` () =
-    let a = WithInterface(1)
-    let aCasted = (a :> IHasAdd)
-    let res = aCasted.Add 2 1
+let ``Class interface from another module works`` () =
+    let a = WithCrossModuleInterface(1)
+    let res = (a :> Fable.Tests.ClassInterfaceTests.IHasAdd).Add 2 1
     res |> equal 4
-
-let doAddWithInterface (i: IHasAdd) =
-    i.Add 3 4
-
-[<Fact>]
-let ``Class interface with callout works`` () =
-    let a = WithInterface(1)
-    let aCasted = (a :> IHasAdd)
-    let res = doAddWithInterface aCasted
-    let res2 = doAddWithInterface a
-    res |> equal 8
-    res2 |> equal 8
+    //let res2 = Fable.Tests.ClassInterfaceTests.doAddWithInterface(a) // todo: this breaks because duplicate interface + module not imported
+    //res2 |> equal 8


### PR DESCRIPTION
**Track when an interface has been declared, and redirect future calls to the same one. This allows more than 1 class to implement the same interface.**

This is kind of an early pass though as the compiler object is only scoped to the file and not the whole project, so each one tries to declare its own version.

This approach also brings up some interesting caveats around multi-stage compilation (for libraries etc) when the second stage has no memory of interfaces declared in the first. We might just be able to exclude stuff for the built in libraries as a temporary workaround though, so perhaps not a dealbreaker.