### PR TITLE
[Beam] Fix System.Random seeded to use per-instance state

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [All] Fix unnecessary object allocations during AST traversal when visiting `Import` expressions (by Repo Assist)
 * [Beam] Fix `System.Random.Next(0)` implementation (by @ncave)
 * [Python] Fix `System.Random` seeded implementation  (by @ncave)
+* [Beam] Fix `System.Random` seeded implementation to use per-instance state (by @dbrattli)
 * [Dart] Fix `Array.compareWith` comparing lengths before elements, producing wrong results for arrays with common prefixes (fixes #2961)
 * [Python] Fix unsafe option unwrapping in `DateTimeOffset.get_Offset` and regex replacements (by @dbrattli)
 * [All] Replace unsafe option `.Value` unwrapping with safe alternatives in Python/Replacements.fs and Rust/Fable2Rust.fs (code scanning alerts IONIDE-006)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [All] Fix unnecessary object allocations during AST traversal when visiting `Import` expressions (by Repo Assist)
 * [Beam] Fix `System.Random.Next(0)` implementation (by @ncave)
 * [Python] Fix `System.Random` seeded implementation  (by @ncave)
+* [Beam] Fix `System.Random` seeded implementation to use per-instance state (by @dbrattli)
 * [Dart] Fix `Array.compareWith` comparing lengths before elements, producing wrong results for arrays with common prefixes (fixes #2961)
 * [Python] Fix unsafe option unwrapping in `DateTimeOffset.get_Offset` and regex replacements (by @dbrattli)
 * [All] Replace unsafe option `.Value` unwrapping with safe alternatives in Python/Replacements.fs and Rust/Fable2Rust.fs (code scanning alerts IONIDE-006)

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -4050,18 +4050,24 @@ let private randoms
         match args with
         | [ seed ] -> Helper.LibCall(com, "fable_random", "new_seeded", t, [ seed ], ?loc = r) |> Some
         | _ -> Helper.LibCall(com, "fable_random", "new", t, [], ?loc = r) |> Some
-    | "Next", Some _ ->
+    | "Next", Some thisArg ->
         match args with
-        | [] -> Helper.LibCall(com, "fable_random", "next", t, [], ?loc = r) |> Some
-        | [ maxVal ] -> Helper.LibCall(com, "fable_random", "next", t, [ maxVal ], ?loc = r) |> Some
+        | [] -> Helper.LibCall(com, "fable_random", "next", t, [ thisArg ], ?loc = r) |> Some
+        | [ maxVal ] ->
+            Helper.LibCall(com, "fable_random", "next", t, [ thisArg; maxVal ], ?loc = r)
+            |> Some
         | [ minVal; maxVal ] ->
-            Helper.LibCall(com, "fable_random", "next", t, [ minVal; maxVal ], ?loc = r)
+            Helper.LibCall(com, "fable_random", "next", t, [ thisArg; minVal; maxVal ], ?loc = r)
             |> Some
         | _ -> None
-    | "NextDouble", Some _ -> Helper.LibCall(com, "fable_random", "next_double", t, [], ?loc = r) |> Some
-    | "NextBytes", Some _ ->
+    | "NextDouble", Some thisArg ->
+        Helper.LibCall(com, "fable_random", "next_double", t, [ thisArg ], ?loc = r)
+        |> Some
+    | "NextBytes", Some thisArg ->
         match args with
-        | [ arr ] -> Helper.LibCall(com, "fable_random", "next_bytes", t, [ arr ], ?loc = r) |> Some
+        | [ arr ] ->
+            Helper.LibCall(com, "fable_random", "next_bytes", t, [ thisArg; arr ], ?loc = r)
+            |> Some
         | _ -> None
     | _ -> None
 

--- a/src/fable-library-beam/fable_list.erl
+++ b/src/fable-library-beam/fable_list.erl
@@ -617,19 +617,19 @@ take(Count, List) ->
 %% avoiding any delegation through seq.erl (which would cause circular recursion).
 %%
 %% Calling convention: Randomizer is fun(ok) -> float()  (F# unit -> float curried).
-%% Random (System.Random) is the atom ok; all randomness goes through fable_random.
+%% Random (System.Random) is a reference() holding per-instance PRNG state.
 
 -spec random_shuffle_by(fun((ok) -> float()), list()) -> list().
 random_shuffle_by(Randomizer, Xs) ->
     shuffle_loop(Randomizer, erlang:list_to_tuple(Xs), erlang:length(Xs) - 1).
 
--spec random_shuffle_with(ok, list()) -> list().
-random_shuffle_with(_Random, Xs) ->
-    random_shuffle_by(fun(_) -> fable_random:next_double() end, Xs).
+-spec random_shuffle_with(reference(), list()) -> list().
+random_shuffle_with(Random, Xs) ->
+    random_shuffle_by(fun(_) -> fable_random:next_double(Random) end, Xs).
 
 -spec random_shuffle(list()) -> list().
 random_shuffle(Xs) ->
-    random_shuffle_with(ok, Xs).
+    random_shuffle_with(fable_random:new(), Xs).
 
 -spec random_choice_by(fun((ok) -> float()), list()) -> term().
 random_choice_by(_Randomizer, []) ->
@@ -644,13 +644,13 @@ random_choice_by(Randomizer, Xs) ->
             lists:nth(erlang:trunc(R * Len) + 1, Xs)
     end.
 
--spec random_choice_with(ok, list()) -> term().
-random_choice_with(_Random, Xs) ->
-    random_choice_by(fun(_) -> fable_random:next_double() end, Xs).
+-spec random_choice_with(reference(), list()) -> term().
+random_choice_with(Random, Xs) ->
+    random_choice_by(fun(_) -> fable_random:next_double(Random) end, Xs).
 
 -spec random_choice(list()) -> term().
 random_choice(Xs) ->
-    random_choice_with(ok, Xs).
+    random_choice_with(fable_random:new(), Xs).
 
 -spec random_choices_by(fun((ok) -> float()), non_neg_integer(), list()) -> list().
 random_choices_by(Randomizer, Count, Xs) ->
@@ -678,13 +678,13 @@ choices_loop(Randomizer, Arr, Len, N, Acc) ->
             choices_loop(Randomizer, Arr, Len, N - 1, [E | Acc])
     end.
 
--spec random_choices_with(ok, non_neg_integer(), list()) -> list().
-random_choices_with(_Random, Count, Xs) ->
-    random_choices_by(fun(_) -> fable_random:next_double() end, Count, Xs).
+-spec random_choices_with(reference(), non_neg_integer(), list()) -> list().
+random_choices_with(Random, Count, Xs) ->
+    random_choices_by(fun(_) -> fable_random:next_double(Random) end, Count, Xs).
 
 -spec random_choices(non_neg_integer(), list()) -> list().
 random_choices(Count, Xs) ->
-    random_choices_with(ok, Count, Xs).
+    random_choices_with(fable_random:new(), Count, Xs).
 
 -spec random_sample_by(fun((ok) -> float()), non_neg_integer(), list()) -> list().
 random_sample_by(Randomizer, Count, Xs) ->
@@ -703,13 +703,13 @@ random_sample_by(Randomizer, Count, Xs) ->
             end
     end.
 
--spec random_sample_with(ok, non_neg_integer(), list()) -> list().
-random_sample_with(_Random, Count, Xs) ->
-    random_sample_by(fun(_) -> fable_random:next_double() end, Count, Xs).
+-spec random_sample_with(reference(), non_neg_integer(), list()) -> list().
+random_sample_with(Random, Count, Xs) ->
+    random_sample_by(fun(_) -> fable_random:next_double(Random) end, Count, Xs).
 
 -spec random_sample(non_neg_integer(), list()) -> list().
 random_sample(Count, Xs) ->
-    random_sample_with(ok, Count, Xs).
+    random_sample_with(fable_random:new(), Count, Xs).
 
 %% Partial Fisher-Yates: after Count swaps the first Count positions hold the sample.
 sample_loop(_Randomizer, Arr, _Len, Count, I) when I >= Count ->

--- a/src/fable-library-beam/fable_random.erl
+++ b/src/fable-library-beam/fable_random.erl
@@ -3,62 +3,76 @@
 -export([
     new/0,
     new_seeded/1,
-    next/0,
     next/1,
     next/2,
-    next_double/0,
-    next_bytes/1
+    next/3,
+    next_double/1,
+    next_bytes/2
 ]).
 
--spec new() -> ok.
--spec new_seeded(integer()) -> ok.
--spec next() -> non_neg_integer().
--spec next(integer()) -> non_neg_integer().
--spec next(integer(), integer()) -> integer().
--spec next_double() -> float().
--spec next_bytes(tuple() | reference()) -> ok.
+%% All functions take a Ref (process dictionary key) as the first argument,
+%% so each Random instance has its own independent PRNG state.
 
-%% System.Random() — no-op, uses default process-level PRNG state.
+%% System.Random() — create a new instance with a random seed.
+-spec new() -> reference().
 new() ->
-    ok.
+    Ref = make_ref(),
+    put(Ref, rand:seed_s(exsss)),
+    Ref.
 
-%% System.Random(seed) — seed the process-level PRNG for deterministic output.
+%% System.Random(seed) — create a new instance with a deterministic seed.
+-spec new_seeded(integer()) -> reference().
 new_seeded(Seed) ->
-    rand:seed(exsss, Seed),
-    ok.
+    Ref = make_ref(),
+    put(Ref, rand:seed_s(exsss, Seed)),
+    Ref.
 
 %% Random.Next() — returns a non-negative integer less than Int32.MaxValue.
-next() ->
-    rand:uniform(2147483647) - 1.
+-spec next(reference()) -> non_neg_integer().
+next(Ref) ->
+    {Val, NewState} = rand:uniform_s(2147483647, get(Ref)),
+    put(Ref, NewState),
+    Val - 1.
 
 %% Random.Next(maxValue) — returns a non-negative integer less than maxValue.
-next(0) ->
+-spec next(reference(), integer()) -> non_neg_integer().
+next(_Ref, 0) ->
     0;
-next(MaxValue) when MaxValue > 0 ->
-    rand:uniform(MaxValue) - 1;
-next(_) ->
-    erlang:error(badarg).
-
-%% Random.Next(minValue, maxValue) — returns an integer in [minValue, maxValue).
-next(MinValue, MaxValue) when MaxValue > MinValue ->
-    MinValue + rand:uniform(MaxValue - MinValue) - 1;
+next(Ref, MaxValue) when MaxValue > 0 ->
+    {Val, NewState} = rand:uniform_s(MaxValue, get(Ref)),
+    put(Ref, NewState),
+    Val - 1;
 next(_, _) ->
     erlang:error(badarg).
 
+%% Random.Next(minValue, maxValue) — returns an integer in [minValue, maxValue).
+-spec next(reference(), integer(), integer()) -> integer().
+next(Ref, MinValue, MaxValue) when MaxValue > MinValue ->
+    Range = MaxValue - MinValue,
+    {Val, NewState} = rand:uniform_s(Range, get(Ref)),
+    put(Ref, NewState),
+    MinValue + Val - 1;
+next(_, _, _) ->
+    erlang:error(badarg).
+
 %% Random.NextDouble() — returns a float in [0.0, 1.0).
-next_double() ->
-    rand:uniform().
+-spec next_double(reference()) -> float().
+next_double(Ref) ->
+    {Val, NewState} = rand:uniform_s(get(Ref)),
+    put(Ref, NewState),
+    Val.
 
 %% Random.NextBytes(byte[]) — fills a byte array with random bytes.
-%% Uses the seeded rand state so results are deterministic after seeding.
-%% Accepts both direct byte_array tuples and process dictionary references.
-next_bytes({byte_array, Size, AtomicsRef}) ->
-    fill_random_bytes(AtomicsRef, Size, 1);
-next_bytes(PdRef) when is_reference(PdRef) ->
-    next_bytes(get(PdRef)).
+-spec next_bytes(reference(), tuple() | reference()) -> ok.
+next_bytes(Ref, {byte_array, Size, AtomicsRef}) ->
+    fill_random_bytes(Ref, AtomicsRef, Size, 1);
+next_bytes(Ref, PdRef) when is_reference(PdRef) ->
+    next_bytes(Ref, get(PdRef)).
 
-fill_random_bytes(_AtomicsRef, 0, _Idx) ->
+fill_random_bytes(_Ref, _AtomicsRef, 0, _Idx) ->
     ok;
-fill_random_bytes(AtomicsRef, Remaining, Idx) ->
-    atomics:put(AtomicsRef, Idx, rand:uniform(256) - 1),
-    fill_random_bytes(AtomicsRef, Remaining - 1, Idx + 1).
+fill_random_bytes(Ref, AtomicsRef, Remaining, Idx) ->
+    {Val, NewState} = rand:uniform_s(256, get(Ref)),
+    put(Ref, NewState),
+    atomics:put(AtomicsRef, Idx, Val - 1),
+    fill_random_bytes(Ref, AtomicsRef, Remaining - 1, Idx + 1).

--- a/tests/Beam/RandomTests.fs
+++ b/tests/Beam/RandomTests.fs
@@ -70,33 +70,14 @@ let ``test System.Random works`` () =
     let x = rnd.NextDouble()
     (x >= 0.0 && x < 1.0) |> equal true
 
-// // Broken test, every new Random seeded instance resets a global seed
-// [<Fact>]
-// let ``test System.Random seeded works`` () =
-//     let rnd1 = Random(1234)
-//     let rnd2 = Random(1234)
-//     rnd1.Next() |> equal (rnd2.Next())
-//     rnd1.Next(100) |> equal (rnd2.Next(100))
-//     rnd1.Next(1000, 10000) |> equal (rnd2.Next(1000, 10000))
-//     rnd1.NextDouble() |> equal (rnd2.NextDouble())
-
-// Testing the seeded random sequences separately works, but is not ideal
 [<Fact>]
 let ``test System.Random seeded works`` () =
     let rnd1 = Random(1234)
-    let a1 = rnd1.Next()
-    let a2 = rnd1.Next(100)
-    let a3 = rnd1.Next(1000, 10000)
-    let a4 = rnd1.NextDouble()
     let rnd2 = Random(1234)
-    let b1 = rnd2.Next()
-    let b2 = rnd2.Next(100)
-    let b3 = rnd2.Next(1000, 10000)
-    let b4 = rnd2.NextDouble()
-    a1 |> equal b1
-    a2 |> equal b2
-    a3 |> equal b3
-    a4 |> equal b4
+    rnd1.Next() |> equal (rnd2.Next())
+    rnd1.Next(100) |> equal (rnd2.Next(100))
+    rnd1.Next(1000, 10000) |> equal (rnd2.Next(1000, 10000))
+    rnd1.NextDouble() |> equal (rnd2.NextDouble())
 
 [<Fact>]
 let ``test System.Random seeded validates arguments`` () =
@@ -124,22 +105,10 @@ let ``test System.Random.NextBytes works`` () =
     buffer.Length |> equal 16
     buffer = Array.create 16 0uy |> equal false
 
-// // Broken test, every new Random seeded instance resets a global seed
-// [<Fact>]
-// let ``test System.Random.NextBytes seeded works`` () =
-//     let buffer1 = Array.create 4 0uy
-//     let buffer2 = Array.create 4 0uy
-//     Random(5432).NextBytes(buffer1)
-//     Random(5432).NextBytes(buffer2)
-//     buffer1 |> equal buffer2
-
-// Testing the seeded random sequences separately works, but is not ideal
 [<Fact>]
 let ``test System.Random.NextBytes seeded works`` () =
     let buffer1 = Array.create 4 0uy
     let buffer2 = Array.create 4 0uy
-    let rnd1 = Random(5432)
-    rnd1.NextBytes(buffer1)
-    let rnd2 = Random(5432)
-    rnd2.NextBytes(buffer2)
+    Random(5432).NextBytes(buffer1)
+    Random(5432).NextBytes(buffer2)
     buffer1 |> equal buffer2


### PR DESCRIPTION
## Summary
- Rewrote `fable_random.erl` to use Erlang's functional `rand` API (`seed_s`/`uniform_s`) with per-instance state stored in the process dictionary (keyed by `make_ref()`), instead of the process-level `rand:seed`/`rand:uniform` which shared global state
- Updated Beam `Replacements.fs` to pass `thisArg` (the Random instance ref) to all `fable_random` library calls
- Updated `fable_list.erl` `random_*_with` functions to pass the Random ref through to `fable_random:next_double/1`
- Uncommented the two previously-broken tests that verify two independently-seeded Random instances produce identical sequences

This fixes the bug where creating a second `Random(seed)` instance would reset the PRNG state for all instances, since they all shared Erlang's process-level random state.

## Test plan
- [x] All 2392 Beam tests pass (0 failures)
- [x] Previously-commented seeded Random tests now uncommented and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)